### PR TITLE
NuGet config for msbuild to find Episerver packages

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageRestore>
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="Episerver" value="http://nuget.episerver.com/feed/packages.svc/" />
+  </packageSources>
+</configuration>

--- a/Sources/EPiServer.Reference.Commerce.Manager/EPiServer.Reference.Commerce.Manager.csproj
+++ b/Sources/EPiServer.Reference.Commerce.Manager/EPiServer.Reference.Commerce.Manager.csproj
@@ -277,7 +277,6 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="App_Data\log\placeholder.txt" />
     <Content Include="BlobStorage\Public\placeholder.txt" />
     <Content Include="Default.aspx" />
     <Content Include="EPiServerDefault.aspx" />
@@ -342,6 +341,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="App_Data\log\" />
     <Folder Include="modulesbin\" />
     <Folder Include="Properties\" />
   </ItemGroup>


### PR DESCRIPTION
I added NuGet.config into solution folder root. All build environments are not controlled by developers and for that reason solution should give a hint where to download episerver binaries. NuGet.Config is built for that. https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior

After this change I was able to make VSO builds and Azure Git deployments (both) work. Before this they both crashed on missing Episerver binaries. 

Personally I would added a solution folder into visual studio and added file there too but I didn't want to manipulate the solution file. 