### PR TITLE
Fix QuickSliver UI when using phone, collapse navabar doesnt visible

### DIFF
--- a/Sources/EPiServer.Reference.Commerce.Site/Styles/Recommendations/recommendations.less
+++ b/Sources/EPiServer.Reference.Commerce.Site/Styles/Recommendations/recommendations.less
@@ -90,3 +90,6 @@ div.recommendations {
         border: none;
     }
 }
+.collapse{
+    display:none;
+}


### PR DESCRIPTION
Fix QuickSliver UI when using phone, collapse navabar doesnt visible like this: 
http://imgur.com/a/zr

![ui](https://cloud.githubusercontent.com/assets/1639657/26484983/3ef74062-421f-11e7-9a9d-16193ebcb8f8.PNG)
