### PR TITLE
Update Web.config

### DIFF
--- a/Sources/EPiServer.Reference.Commerce.Site/Web.config
+++ b/Sources/EPiServer.Reference.Commerce.Site/Web.config
@@ -164,10 +164,6 @@
         <bindingRedirect oldVersion="0.0.0.0-2.0.1.0" newVersion="2.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>


### PR DESCRIPTION
Remove duplicate Castle.Core reference which causes build warning: MSB3277: Found conflicts between different versions of "Castle.Core" that could not be resolved.