### PR TITLE
Example code which can demonstrate support ticket 375768

### DIFF
--- a/Sources/EPiServer.Reference.Commerce.Site/Features/Cart/Controllers/CartController.cs
+++ b/Sources/EPiServer.Reference.Commerce.Site/Features/Cart/Controllers/CartController.cs
@@ -49,7 +49,7 @@ namespace EPiServer.Reference.Commerce.Site.Features.Cart.Controllers
 
         [HttpPost]
         [AllowDBWrite]
-        public async Task<ActionResult> AddToCart(string code)
+        public async Task<ActionResult> AddToCart(string code, string warehouseCode)
         {
             ModelState.Clear();
 
@@ -58,7 +58,7 @@ namespace EPiServer.Reference.Commerce.Site.Features.Cart.Controllers
                 _cart = _cartService.LoadOrCreateCart(_cartService.DefaultCartName);
             }
 
-            var result = _cartService.AddToCart(Cart, code, 1);
+            var result = _cartService.AddToCart(Cart, code, warehouseCode, 1);
             if (result.EntriesAddedToCart)
             {
                 _orderRepository.Save(Cart);

--- a/Sources/EPiServer.Reference.Commerce.Site/Features/Cart/Controllers/WishListController.cs
+++ b/Sources/EPiServer.Reference.Commerce.Site/Features/Cart/Controllers/WishListController.cs
@@ -72,7 +72,7 @@ namespace EPiServer.Reference.Commerce.Site.Features.Cart.Controllers
                 return WishListMiniCartDetails();
             }
 
-            var result = _cartService.AddToCart(WishList, code, 1);
+            var result = _cartService.AddToCart(WishList, code, null, 1);
             if (result.EntriesAddedToCart)
             {
                 _orderRepository.Save(WishList);

--- a/Sources/EPiServer.Reference.Commerce.Site/Features/Cart/Services/ICartService.cs
+++ b/Sources/EPiServer.Reference.Commerce.Site/Features/Cart/Services/ICartService.cs
@@ -11,7 +11,7 @@ namespace EPiServer.Reference.Commerce.Site.Features.Cart.Services
 {
     public interface ICartService
     {
-        AddToCartResult AddToCart(ICart cart, string code, decimal quantity);
+        AddToCartResult AddToCart(ICart cart, string code, string warehouseCode, decimal quantity);
         CartChangeData ChangeCartItem(ICart cart, int shipmentId, string code, decimal quantity, string size, string newSize, string displayName);
         void SetCartCurrency(ICart cart, Currency currency);
         IDictionary<ILineItem, IList<ValidationIssue>> RequestInventory(ICart cart);

--- a/Sources/EPiServer.Reference.Commerce.Site/Features/Checkout/Services/AnonymousPurchaseValidation.cs
+++ b/Sources/EPiServer.Reference.Commerce.Site/Features/Checkout/Services/AnonymousPurchaseValidation.cs
@@ -21,7 +21,7 @@ namespace EPiServer.Reference.Commerce.Site.Features.Checkout.Services
 
         private bool ValidateBillingAddress(ModelStateDictionary modelState, CheckoutViewModel viewModel)
         {
-            if (viewModel.UseBillingAddressForShipment)
+            if (viewModel.UseBillingAddressForShipment || viewModel.Shipments.Count > 1)
             {
                 foreach (var state in modelState.Where(x => x.Key.StartsWith("Shipments")).ToArray())
                 {

--- a/Sources/EPiServer.Reference.Commerce.Site/Features/Checkout/Services/CheckoutAddressHandling.cs
+++ b/Sources/EPiServer.Reference.Commerce.Site/Features/Checkout/Services/CheckoutAddressHandling.cs
@@ -96,9 +96,12 @@ namespace EPiServer.Reference.Commerce.Site.Features.Checkout.Services
         {
             LoadBillingAddressFromAddressBook(viewModel);
             LoadShippingAddressesFromAddressBook(viewModel);
-            if (viewModel.UseBillingAddressForShipment)
+            if (viewModel.UseBillingAddressForShipment || viewModel.Shipments.Any(s => string.IsNullOrEmpty(s.Address?.Name)))
             {
-                viewModel.Shipments.Single().Address = viewModel.BillingAddress;
+                foreach (var item in viewModel.Shipments)
+                {
+                    item.Address = viewModel.BillingAddress;
+                }
             }
         }
 
@@ -106,10 +109,14 @@ namespace EPiServer.Reference.Commerce.Site.Features.Checkout.Services
         {
             SetDefaultBillingAddressName(viewModel);
 
-            if (viewModel.UseBillingAddressForShipment)
+            if (viewModel.UseBillingAddressForShipment || viewModel.Shipments.Any(s => string.IsNullOrEmpty(s.Address?.Name)))
             {
                 SetDefaultShippingAddressesNames(viewModel);
-                viewModel.Shipments.Single().Address = viewModel.BillingAddress;
+                foreach (var item in viewModel.Shipments)
+                {
+                    item.Address = viewModel.BillingAddress;
+                }
+                
             }
         }
     }

--- a/Sources/EPiServer.Reference.Commerce.Site/Infrastructure/SiteImport/CreateOrdersStep.cs
+++ b/Sources/EPiServer.Reference.Commerce.Site/Infrastructure/SiteImport/CreateOrdersStep.cs
@@ -184,7 +184,7 @@ namespace EPiServer.Reference.Commerce.Site.Infrastructure.SiteImport
 
             foreach (var item in orderGroup.Details)
             {
-                _cartService.AddToCart(order, item.SKU, item.Quantity);
+                _cartService.AddToCart(order, item.SKU, null, item.Quantity);
             }
 
             _orderValidationService.ValidateOrder(order);

--- a/Sources/EPiServer.Reference.Commerce.Site/Scripts/js/Cart.js
+++ b/Sources/EPiServer.Reference.Commerce.Site/Scripts/js/Cart.js
@@ -93,14 +93,14 @@
         var form = $(this).closest("form");
         var formContainer = $("#" + form.data("container"));
         var skuCode = $("#code", form).val();
-
+        var warehouseCode = $("#warehouseCode", form).val();
         $("#CartWarningMessage").hide()
         $(".warning-message", $("#CartWarningMessage")).html("");
 
         $.ajax({
             type: "POST",
             url: form[0].action,
-            data: { code: skuCode },
+            data: { code: skuCode, warehouseCode: warehouseCode },
             success: function (result) {
 
                 formContainer.html($(result));

--- a/Sources/EPiServer.Reference.Commerce.Site/Views/Warehouse/_Availability.cshtml
+++ b/Sources/EPiServer.Reference.Commerce.Site/Views/Warehouse/_Availability.cshtml
@@ -10,7 +10,7 @@
             using (Html.BeginForm("AddToCart", "Cart", FormMethod.Post, new { @class = "warehouse", data_container = "MiniCart" }))
             {
 
-                <div class="btn-group btn-group-sm">
+                <div class="btn-group btn-group-sm btn-group-vertical">
                     <button type="button"
                             class="btn btn-sm btn-default warehouse-quickview-button"
                             data-target="#ModalDialog"
@@ -23,6 +23,13 @@
                     </button>
                     <input type="hidden" class="skuCode" value="@warehouse.SkuCode" />
                     <input type="hidden" class="warehouseCode" value="@warehouse.WarehouseCode" />
+
+                    @using (Html.BeginForm("AddToCart", "Cart", FormMethod.Post, new { @class = "form-inline", data_container = "MiniCart" }))
+                    {
+                        @Html.Hidden("code", @warehouse.SkuCode)
+                        @Html.Hidden("warehouseCode", @warehouse.WarehouseCode)
+                        <button type="submit" role="button" class="btn btn-primary jsAddToCart" data-container="MiniCart"><span class="glyphicon glyphicon-shopping-cart"></span> @Html.Translate("/Product/Button/AddToCart")</button>
+                    }
                 </div>
             }
         }


### PR DESCRIPTION
Hello, 

This is a commit for demonstrating an issue currently being worked on in support ticket 375768.  Changes allow adding a variant specifically from a particular warehouse on the product page.  The issue is that if a variant is added from any warehouse other than the main fulfillment center, then if you edit any part of the shipping address for that shipment in commerce manager, the shipment's warehouse will be changed to the main fulfillment center.  I will update the support ticket separately.  Thanks!

Kurt